### PR TITLE
Fixed some misspellings in alert text

### DIFF
--- a/Powerup/CustomizeAvatarViewController.swift
+++ b/Powerup/CustomizeAvatarViewController.swift
@@ -96,7 +96,7 @@ class CustomizeAvatarViewController: UIViewController {
         do {
             try dataSource.createAvatar(avatar)
         } catch _ {
-            let alert = UIAlertController(title: "Warning", message: "Failed to save avatar, please retry this action. If that doesn't help, try restaring or reinstalling the app.", preferredStyle: .alert)
+            let alert = UIAlertController(title: "Warning", message: "Failed to save avatar, please retry this action. If that doesn't help, try restarting or reinstalling the app.", preferredStyle: .alert)
             
             // Unwind to Start View when Ok Button is pressed.
             let okButton = UIAlertAction(title: "OK", style: .cancel, handler: {action in

--- a/Powerup/ResultsViewController.swift
+++ b/Powerup/ResultsViewController.swift
@@ -48,7 +48,7 @@ class ResultsViewController: UIViewController {
             }
             
         } catch _ {
-            let alert = UIAlertController(title: "Warning", message: "Error fetching scenario data from database.", preferredStyle: .alert)
+            let alert = UIAlertController(title: "Warning", message: "Error fetching scenario data from database. Please retry this action. If that doesn't help, try restarting or reinstalling the app.", preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK", style: .default))
             self.present(alert, animated: true, completion: nil)
             


### PR DESCRIPTION
1. I just fixed some spelling mistakes (restarting)
CustomizeAvatarViewController, in func saveAvatar()
2. Add the same suggestion as for the other errors. ResultsViewController, line 53
There is no instance of an 'alright' button. ShopViewController.swift, So I just leave that.