### PR TITLE
Fix the code so that mini-game tutorials do not show up after 1st time

### DIFF
--- a/Powerup/MinesweeperGameScene.swift
+++ b/Powerup/MinesweeperGameScene.swift
@@ -245,14 +245,21 @@ class MinesweeperGameScene: SKScene {
             }
         }
         
-        // Show tutorial scene. After that, start the game.
-        tutorialScene = SKTutorialScene(namedImages: tutorialSceneImages, size: size) {
+        if !UserDefaults.standard.bool(forKey: "MineTutsViewed") {
+            // Show tutorial scene. After that, start the game.
+            tutorialScene = SKTutorialScene(namedImages: tutorialSceneImages, size: size) {
+                self.newRound()
+                self.inTutorial = false
+            }
+            tutorialScene.position = CGPoint(x: size.width / 2.0, y: size.height / 2.0)
+            tutorialScene.zPosition = tutorialSceneLayer
+            addChild(tutorialScene)
+            UserDefaults.standard.set(true, forKey: "MineTutsViewed")
+        } else {
+            // It is not the user's 1st time playing the game, so skip tutorials
             self.newRound()
             self.inTutorial = false
         }
-        tutorialScene.position = CGPoint(x: size.width / 2.0, y: size.height / 2.0)
-        tutorialScene.zPosition = tutorialSceneLayer
-        addChild(tutorialScene)
     }
     
     /**

--- a/Powerup/SinkToSwimGameScene.swift
+++ b/Powerup/SinkToSwimGameScene.swift
@@ -419,15 +419,23 @@ class SinkToSwimGameScene: SKScene {
         // Start the wobbling animation of the boat.
         startBoatWobblingAnimation()
         
-        // Show tutorial scene. After that, start the game (aka start the timer).
-        tutorialScene = SKTutorialScene(namedImages: tutorialSceneImages, size: size) {
+        if !UserDefaults.standard.bool(forKey: "SwimTutsViewed") {
+            // Show tutorial scene. After that, start the game (aka start the timer).
+            tutorialScene = SKTutorialScene(namedImages: tutorialSceneImages, size: size) {
+                let timerTickAction = SKAction.sequence([SKAction.wait(forDuration: 1.0), SKAction.run({self.tickTimer()})])
+                self.run(SKAction.repeatForever(timerTickAction), withKey: "timer_tick")
+                self.inTutorial = false
+            }
+            tutorialScene.position = CGPoint(x: size.width / 2.0, y: size.height / 2.0)
+            tutorialScene.zPosition = tutorialSceneLayer
+            addChild(tutorialScene)
+            UserDefaults.standard.set(true, forKey: "SwimTutsViewed")
+        } else {
+            // It is not the user's 1st time playing the game, so skip tutorials
             let timerTickAction = SKAction.sequence([SKAction.wait(forDuration: 1.0), SKAction.run({self.tickTimer()})])
             self.run(SKAction.repeatForever(timerTickAction), withKey: "timer_tick")
             self.inTutorial = false
         }
-        tutorialScene.position = CGPoint(x: size.width / 2.0, y: size.height / 2.0)
-        tutorialScene.zPosition = tutorialSceneLayer
-        addChild(tutorialScene)
     }
     
     // Being called every frame.

--- a/Powerup/StartViewController.swift
+++ b/Powerup/StartViewController.swift
@@ -46,6 +46,10 @@ class StartViewController: UIViewController {
     }
     
     @IBAction func newAvatarButtonTouched(_ sender: UIButton) {
+        // Allow the mini game tutorials to be shown for the first time
+        UserDefaults.standard.set(false, forKey: "MineTutsViewed")
+        UserDefaults.standard.set(false, forKey: "VocabTutsViewed")
+        UserDefaults.standard.set(false, forKey: "SwimTutsViewed")
         // If previous avatar exists, warns the player that previous data will be lost.
         if dataSource.avatarExists() {
             let alert = UIAlertController(title: "Are you sure?", message: "If you start a new game, previous data and all Karma points will be lost!", preferredStyle: .alert)

--- a/Powerup/VocabMatchingGameScene.swift
+++ b/Powerup/VocabMatchingGameScene.swift
@@ -243,13 +243,19 @@ class VocabMatchingGameScene: SKScene {
         // Add end scene.
         addChild(endSceneSprite)
         
-        // Show tutorial scene. After that, start the game.
-        tutorialScene = SKTutorialScene(namedImages: tutorialSceneImages, size: size) {
+        if !UserDefaults.standard.bool(forKey: "VocabTutsViewed") {
+            // Show tutorial scene. After that, start the game.
+            tutorialScene = SKTutorialScene(namedImages: tutorialSceneImages, size: size) {
+                self.nextRound()
+            }
+            tutorialScene.position = CGPoint(x: size.width / 2.0, y: size.height / 2.0)
+            tutorialScene.zPosition = tutorialSceneLayer
+            addChild(tutorialScene)
+            UserDefaults.standard.set(true, forKey: "VocabTutsViewed")
+        } else {
+            // It is not the user's 1st time playing the game, so skip tutorials
             self.nextRound()
         }
-        tutorialScene.position = CGPoint(x: size.width / 2.0, y: size.height / 2.0)
-        tutorialScene.zPosition = tutorialSceneLayer
-        addChild(tutorialScene)
     }
     
     // Spawn tiles for the next round. Completion closure is for unit tests.


### PR DESCRIPTION
### Description
In order to ensure that the tutorials are only shown the 1st time the mini games are played, UserDefaults variables were used to record whether it was the user's first time playing or not.

Fixes #142 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)


### How Has This Been Tested?
All three mini games were tested and replayed on an emulator to see whether the tutorials would show up again.

Steps to Reproduce:
1. Create new avatar
2. Complete the Home scenario
3. In the School scenario, choose the dialogues that prompt the user to have sex
4. Play the Minesweeper game
5. Replay the School scenario and replay the Minesweeper game. The tutorials will not show anymore.
6. Complete the Hospital scenario and play the Vocab Match game
7. Replay the Hospital scenario and replay the Vocab Match game. The tutorials will not show anymore.
8. Complete the Library scenario and play the Sink to Swim game
9. Replay the Library scenario and replay the Sink to Swim game. The tutorials will not show anymore.

### Checklist:

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials
- [X] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [X] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules

