### PR TITLE
PowerUp iOS: Fix the 'About' screen to disable user input

### DIFF
--- a/Powerup/Base.lproj/Main.storyboard
+++ b/Powerup/Base.lproj/Main.storyboard
@@ -32,7 +32,7 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="about_background" translatesAutoresizingMaskIntoConstraints="NO" id="tEY-r5-Byb">
                                 <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
                             </imageView>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="justified" translatesAutoresizingMaskIntoConstraints="NO" id="FdT-xN-nZO">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="justified" translatesAutoresizingMaskIntoConstraints="NO" id="FdT-xN-nZO">
                                 <rect key="frame" x="35" y="82" width="400" height="278"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <constraints>


### PR DESCRIPTION
In the about screen of the powerup project, the about textfield was editable before however, I
fixed it so that the user can no longer edit in the about section. When
the project is built and runs the issue is fixed.

The only change I made was removing the editable property in the attributes section of main.storyboard in the project.

issue: #137 