### PR TITLE
Fix issue of text getting cut off by UI bounds

### DIFF
--- a/Powerup/Base.lproj/Main.storyboard
+++ b/Powerup/Base.lproj/Main.storyboard
@@ -534,7 +534,7 @@ The app uses Social and Emotional Learning (SEL) to empower middle school girls 
                                             <rect key="frame" x="0.0" y="0.0" width="240.5" height="39"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Sample Text" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="JR9-C4-9RX">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Sample Text" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="JR9-C4-9RX">
                                                     <rect key="frame" x="15" y="0.0" width="210.5" height="39"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>

--- a/Powerup/ScenarioViewController.swift
+++ b/Powerup/ScenarioViewController.swift
@@ -102,6 +102,10 @@ class ScenarioViewController: UIViewController, UITableViewDelegate, UITableView
         
         choicesTableView.delegate = self
         choicesTableView.dataSource = self
+        // Use an arbitrary yet appropriate height value.
+        choicesTableView.estimatedRowHeight = 50; 
+        // Allow dynamic resizing of TableView cells.
+        choicesTableView.rowHeight = UITableViewAutomaticDimension 
         
         // TODO: Configure the image and name of the "Asker" avatar.
         

--- a/Powerup/ScenarioViewController.swift
+++ b/Powerup/ScenarioViewController.swift
@@ -103,7 +103,7 @@ class ScenarioViewController: UIViewController, UITableViewDelegate, UITableView
         choicesTableView.delegate = self
         choicesTableView.dataSource = self
         // Use an arbitrary yet appropriate height value.
-        choicesTableView.estimatedRowHeight = 50; 
+        choicesTableView.estimatedRowHeight = 50
         // Allow dynamic resizing of TableView cells.
         choicesTableView.rowHeight = UITableViewAutomaticDimension 
         


### PR DESCRIPTION
### Description
For some dialogue options, the text is getting cut off by the UI bounds, so the user can't see all of the words. This fixes the problem by allowing dynamic resizing of TableView cells to fit all of the text. It will also adapt to new dialogue options which may be added in the future. However, there is a tradeoff with Issue #199 because the dynamic cells will take up more space, so not all of the dialogue options will be visible to the user initially. A decision will have to be made whether it is better to have dynamic TableView cells that show the entire text or fixed cells that make all dialogue options visible (see pull request #202)

Fixes #143

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Ran on an iPhone 5s emulator. In all of the scenarios, all of the words are visible.

#### Home Example
<img width="575" alt="screen shot 2018-01-19 at 4 04 32 pm" src="https://user-images.githubusercontent.com/34075473/35171849-367a713c-fd33-11e7-916a-e8142c992b42.png">

#### Hospital Example
<img width="575" alt="screen shot 2018-01-19 at 4 04 59 pm" src="https://user-images.githubusercontent.com/34075473/35171850-37b4fb1c-fd33-11e7-926d-ae3aced2e4c5.png">

### Checklist:

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials
- [X] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [X] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
