### PR TITLE
Hide unavailable boxes and correct corresponding unit test

### DIFF
--- a/Powerup/ShopViewController.swift
+++ b/Powerup/ShopViewController.swift
@@ -112,12 +112,12 @@ class ShopViewController: UIViewController {
             // Not enough accessories.
             if (firstAccessoryIndex + boxIndex) >= currDisplayingArray.count {
                 for remainingIndex in boxIndex..<displayBoxCount {
-                    // Grey out the box.
-                    displayBoxes[remainingIndex].image = UIImage(named: greyOutBoxImageName)
+                    // Hide the box.
+                    displayBoxes[remainingIndex].image = UIImage()
                     
-                    // Price Label
-                    priceLabels[remainingIndex].text = "-"
-                    
+                    // Hide the price label
+                    priceLabels[remainingIndex].text = ""
+
                     // Hide check mark.
                     purchasedCheckmark[remainingIndex].isHidden = true
                     

--- a/PowerupTests/ShopViewControllerTests.swift
+++ b/PowerupTests/ShopViewControllerTests.swift
@@ -149,8 +149,8 @@ class ShopViewControllerTests: XCTestCase {
                 XCTAssertEqual(shopViewController.priceLabels[boxIndex].text, String(5))
             } else {
                 // Since there are no other hairs, the other boxes should be unavailable.
-                XCTAssertEqual(shopViewController.displayBoxes[boxIndex].image, UIImage(named: "shop_unavailable_box"))
-                XCTAssertEqual(shopViewController.priceLabels[boxIndex].text, "-")
+                XCTAssertEqual(UIImagePNGRepresentation(shopViewController.displayBoxes[boxIndex].image!), UIImagePNGRepresentation(UIImage()))
+                XCTAssertEqual(shopViewController.priceLabels[boxIndex].text, "")
                 XCTAssertTrue(shopViewController.purchasedCheckmark[boxIndex].isHidden)
                 XCTAssertEqual(shopViewController.displayImages[boxIndex].image, nil)
                 XCTAssertEqual(shopViewController.buttonTexts[boxIndex].text, "")


### PR DESCRIPTION
… correct corresponding unit test

### Description
This contains code to selectively merge relevant parts of pr 187 and 212 -- hide unavailable boxes in the Shop UI and correct corresponding unit test

Fixes #188

### Type of Change:

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Manually tested in iOS Simulator
All unit tests pass

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

