### PR TITLE
Issue 287 fix fading text ssp

### DIFF
--- a/Powerup/OOC-Event-Classes/StorySequencePlayer.swift
+++ b/Powerup/OOC-Event-Classes/StorySequencePlayer.swift
@@ -338,6 +338,8 @@ class StorySequencePlayer: UIView {
         label.font = UIFont(name: fontName, size: fontSize)
         label.text = text
         label.textAlignment = (left) ? .left : .right
+
+        // used to check if a label should fade
         label.tag = currentStep
 
         // resize and reformat to account for word wrapping
@@ -372,6 +374,7 @@ class StorySequencePlayer: UIView {
                     // animate moving all labels, use random value to make the spring jiggle more dynamic
                     Animate(label, dur).setSpring(0.6, 6.5 + (self.randomCGFloat() * 8)).setOptions(.curveEaseOut).move(by: [0, -height])
 
+                    // check the tag to see if it's an old label, and fade if it is
                     if label.tag != self.currentStep {
                         Animate(label, dur).fade(to: fadeTo)
                     }

--- a/Powerup/OOC-Event-Classes/StorySequencePlayer.swift
+++ b/Powerup/OOC-Event-Classes/StorySequencePlayer.swift
@@ -338,6 +338,7 @@ class StorySequencePlayer: UIView {
         label.font = UIFont(name: fontName, size: fontSize)
         label.text = text
         label.textAlignment = (left) ? .left : .right
+        label.tag = currentStep
 
         // resize and reformat to account for word wrapping
         label.numberOfLines = 0
@@ -371,11 +372,8 @@ class StorySequencePlayer: UIView {
                     // animate moving all labels, use random value to make the spring jiggle more dynamic
                     Animate(label, dur).setSpring(0.6, 6.5 + (self.randomCGFloat() * 8)).setOptions(.curveEaseOut).move(by: [0, -height])
 
-                    // if the label isnt't the new label, and alpha is still 1, then reduce alpha
-                    if label != labels.last {
-                        if label.alpha == 1 {
-                            Animate(label, dur).fade(to: fadeTo)
-                        }
+                    if label.tag != self.currentStep {
+                        Animate(label, dur).fade(to: fadeTo)
                     }
                 }
             }

--- a/Powerup/OOC-Event-Classes/StorySequences.swift
+++ b/Powerup/OOC-Event-Classes/StorySequences.swift
@@ -62,11 +62,11 @@ private let home: StorySequence = StorySequence(music: Sounds().scenarioMusic[5]
                                                         pos: pos.far,
                                                         ani: nil)
     ),
-    5: StorySequence.Step(lftEvent: StorySequence.Event(txt: "Things can happen on one or both sides. Now both images are hidden.",
+    5: StorySequence.Step(lftEvent: StorySequence.Event(txt: "Things can happen on one or both sides.",
                                                         img: nil,
                                                         pos: pos.hidden,
                                                         ani: nil),
-                          rgtEvent: StorySequence.Event(txt: nil,
+                          rgtEvent: StorySequence.Event(txt: "Now both images are hidden!",
                                                         img: nil,
                                                         pos: pos.hidden,
                                                         ani: nil)


### PR DESCRIPTION
### Description
Fixes #287

Fixed the issue with the left side text fading too early by assigning a tag to each label equal to the current step index. Then instead of checking if a label had just been added or not, we check if a labels tag equals the current step index before fading.

![image](https://user-images.githubusercontent.com/24572031/41259034-bedf00a4-6d97-11e8-9eb6-9cd5085d34c1.png)


### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

This turned out to be a pretty simple fix. I've added back an example of text labels being added on both sides, and run the sequence to ensure everything still works as expected.

### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes
