### PR TITLE
Changed PopupEventPlayer to use sound file names

### DIFF
--- a/Powerup/AboutViewController.swift
+++ b/Powerup/AboutViewController.swift
@@ -15,7 +15,8 @@ class AboutViewController: UIViewController {
         let model = PopupEvent(topText: "Made with ♥",
                                botText: "by Systers Open Source",
                                imgName: nil,
-                               doSound: false)
+                               slideSound: nil,
+                               badgeSound: nil)
         let popup: PopupEventPlayer = PopupEventPlayer(model)
         self.view.addSubview(popup)
     }

--- a/Powerup/OOC-Event-Classes/PopupEventModel.swift
+++ b/Powerup/OOC-Event-Classes/PopupEventModel.swift
@@ -5,12 +5,14 @@ struct PopupEvent {
     var topText: String?
     var botText: String?
     var imgName: String?
-    var doSound: Bool?
+    var slideSound: String?
+    var badgeSound: String?
 
-    init (topText: String?, botText: String?, imgName: String?, doSound: Bool?) {
+    init (topText: String?, botText: String?, imgName: String?, slideSound: String?, badgeSound: String?) {
         self.topText = topText
         self.botText = botText
         self.imgName = imgName
-        self.doSound = doSound
+        self.slideSound = slideSound
+        self.badgeSound = badgeSound
     }
 }

--- a/Powerup/OOC-Event-Classes/PopupEventPlayer.swift
+++ b/Powerup/OOC-Event-Classes/PopupEventPlayer.swift
@@ -19,7 +19,6 @@ class PopupEventPlayer: UIView {
 
     var width: CGFloat,
         height: CGFloat
-    //var useSound: Bool
 
     var bgColor: UIColor // { didSet { updateContainer() } }
     var borderColor: UIColor // { didSet { updateContainer() } }

--- a/Powerup/OOC-Event-Classes/PopupEventPlayer.swift
+++ b/Powerup/OOC-Event-Classes/PopupEventPlayer.swift
@@ -19,7 +19,7 @@ class PopupEventPlayer: UIView {
 
     var width: CGFloat,
         height: CGFloat
-    var useSound: Bool
+    //var useSound: Bool
 
     var bgColor: UIColor // { didSet { updateContainer() } }
     var borderColor: UIColor // { didSet { updateContainer() } }
@@ -36,8 +36,10 @@ class PopupEventPlayer: UIView {
         imageView: UIImageView
 
     var soundPlayer: SoundPlayer? = SoundPlayer()
-    let sounds = (slideIn: "placeholder",
-                  showImage: "placeholder2")
+    var slideSound: String?
+    var badgeSound: String?
+    let defaultSounds = (slideIn: "placeholder",
+                         showImage: "placeholder2")
 
     private var tapped: Bool
 
@@ -67,7 +69,6 @@ class PopupEventPlayer: UIView {
         self.imageView = UIImageView(frame: CGRect.zero)
 
         self.tapped = false
-        self.useSound = false
 
         super.init(frame: frame)
 
@@ -106,8 +107,11 @@ class PopupEventPlayer: UIView {
             image = UIImage(named: m.imgName!)
             updateImageView()
         }
-        if m.doSound != nil {
-            useSound = m.doSound!
+        if m.slideSound != nil {
+            slideSound = m.slideSound!
+        }
+        if m.badgeSound != nil {
+            badgeSound = m.badgeSound!
         }
     }
 
@@ -266,12 +270,11 @@ class PopupEventPlayer: UIView {
 
         self.delegate?.popupDidShow(sender: self)
 
-        let sound = sounds.slideIn
         let volume: Float = 0.2
 
         let x = UIScreen.main.bounds.width - width
         animateSlideTo(x: x)
-        playSound(fileName: sound, volume: volume)
+        playSound(fileName: slideSound, volume: volume)
 
         DispatchQueue.global(qos: .background).async {
             DispatchQueue.main.asyncAfter(deadline: .now() + self.popupDuration) {
@@ -314,14 +317,13 @@ class PopupEventPlayer: UIView {
 
     private func animateShowImageWithSound() {
         let duration: Double = 0.2
-        let sound = sounds.showImage
         let volume: Float = 0.1
         Animate(imageView, duration).setSpring(0.3, 12).reset().fade(to: 1)
-        playSound(fileName: sound, volume: volume)
+        playSound(fileName: badgeSound, volume: volume)
     }
 
     private func playSound (fileName: String?, volume: Float?) {
-        if useSound && !tapped {
+        if fileName != nil && !tapped {
             guard let sound = fileName else { return }
             guard let player = self.soundPlayer else { return }
             let vol = (volume != nil) ? volume : 1

--- a/Powerup/OOC-Event-Classes/PopupEvents.swift
+++ b/Powerup/OOC-Event-Classes/PopupEvents.swift
@@ -32,7 +32,7 @@ struct PopupEvents {
      */
     func getPopup(type: PopupType, collection: String, popupID: Int) -> PopupEvent? {
 
-        var popup = PopupEvent(topText: nil, botText: nil, imgName: nil, doSound: nil)
+        var popup = PopupEvent(topText: nil, botText: nil, imgName: nil, slideSound: nil, badgeSound: nil)
 
         // change this to the main json containing all sequences
         let fileName = "Popups"
@@ -70,7 +70,8 @@ struct PopupEvents {
                 popup.topText = pop["topText"] as? String
                 popup.botText = pop["botText"] as? String
                 popup.imgName = pop["imgName"] as? String
-                popup.doSound = pop["doSound"] as? Bool
+                popup.slideSound = pop["slideSound"] as? String
+                popup.badgeSound = pop["badgeSound"] as? String
             }
 
         } catch let error {

--- a/Powerup/OOC-Event-Classes/Popups.json
+++ b/Powerup/OOC-Event-Classes/Popups.json
@@ -5,13 +5,15 @@
                 "topText": "test model 1",
                 "botText": "has sound",
                 "imgName": "minesweeper_abstinence_heart",
-                "doSound": true
+                "slideSound": "placeholder",
+                "badgeSound": "placeholder2"
             },
             "2": {
                 "topText": "test model 2 with longer text it should shrink to fit",
                 "botText": "no sound",
                 "imgName": "karma_star",
-                "doSound": false
+                "slideSound": null,
+                "badgeSound": null
             }
         }
     },
@@ -21,13 +23,15 @@
                 "topText": "test model 1",
                 "botText": "has sound",
                 "imgName": "minesweeper_abstinence_heart",
-                "doSound": true
+                "slideSound": "placeholder",
+                "badgeSound": "placeholder2"
             },
             "2": {
                 "topText": "test model 2 with longer text it should shrink to fit",
                 "botText": "no sound",
                 "imgName": "karma_star",
-                "doSound": false
+                "slideSound": null,
+                "badgeSound": null
             }
         }
     }

--- a/PowerupTests/PopupEventPlayerUnitTests.swift
+++ b/PowerupTests/PopupEventPlayerUnitTests.swift
@@ -11,6 +11,8 @@ struct MockPopupEvents {
     let topString = "test top text"
     let botString = "test bottom text"
     let imageName = "minesweeper_abstinence_heart"
+    let slideSound = "placeholder"
+    let badgeSound = "placeholder2"
 
     init() {
         popups = [
@@ -19,22 +21,26 @@ struct MockPopupEvents {
                 1: PopupEvent(topText: topString,
                               botText: botString,
                               imgName: imageName,
-                              doSound: true),
+                              slideSound: slideSound,
+                              badgeSound: badgeSound),
                 // all fields no sound
                 2: PopupEvent(topText: topString,
                               botText: botString,
                               imgName: imageName,
-                              doSound: false),
+                              slideSound: nil,
+                              badgeSound: nil),
                 // no image no sound
                 3: PopupEvent(topText: topString,
                               botText: botString,
                               imgName: nil,
-                              doSound: nil),
+                              slideSound: slideSound,
+                              badgeSound: nil),
                 // empty popups are still presented
                 4: PopupEvent(topText: nil,
                               botText: nil,
                               imgName: nil,
-                              doSound: nil)
+                              slideSound: nil,
+                              badgeSound: badgeSound)
             ]
         ]
     }


### PR DESCRIPTION
### Description
- now the model expects a slide in sound file name and badge sound file name
- leaving one or both empty will negate playing a sound at that time

Fixes #298 

### Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test.

Tested in simulator. The current state of the app does not change, but this feature allows for more customizable popups moving forward.


### Checklist:
**Delete irrelevant options.**

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [X] My changes generate no new warnings 
- [X] New and existing unit tests pass locally with my changes
