### PR TITLE
Issue 306 skip indicator

### DIFF
--- a/Powerup/OOC-Event-Classes/Animate.swift
+++ b/Powerup/OOC-Event-Classes/Animate.swift
@@ -32,6 +32,8 @@ class Animate {
         dur: Double,
         moved: Bool = false
 
+    var originalDuration: Double
+
     private var origin: Array<CGFloat>,
         opacity: Float,
         view: UIView
@@ -40,8 +42,9 @@ class Animate {
         self.view = view
         self.origin = [view.frame.origin.x, view.frame.origin.y]
         self.opacity = view.layer.opacity
-        self.duration = (duration != nil) ? duration! : 0.5
-        self.dur = self.duration
+        self.originalDuration = (duration != nil) ? duration! : 0.5
+        self.duration = self.originalDuration
+        self.dur = self.originalDuration
     }
 
     /* *******************************

--- a/Powerup/OOC-Event-Classes/StorySequencePlayer.swift
+++ b/Powerup/OOC-Event-Classes/StorySequencePlayer.swift
@@ -77,7 +77,7 @@ class StorySequencePlayer: UIView {
         addLPGesture()
     }
 
-    convenience init(delegate: StorySequencePlayerDelegate, model: StorySequence) {
+    convenience init(delegate: StorySequencePlayerDelegate, model: StorySequence, firstTime: Bool) {
         self.init(frame: UIScreen.main.bounds)
 
         self.delegate = delegate
@@ -91,10 +91,40 @@ class StorySequencePlayer: UIView {
                 self.soundPlayer.playSound(sound, 0.1)
             }
         }
+
+        if firstTime == false {
+            showSkipNotice()
+        }
     }
 
     override func didMoveToSuperview() {
         self.delegate?.sequenceDidStart(sender: self)
+    }
+
+    private func showSkipNotice() {
+        let label = UILabel(frame: CGRect(x: 5, y: 5, width: self.bounds.width, height: 0))
+        label.textColor = UIColor.white
+        label.numberOfLines = 0
+        label.lineBreakMode = NSLineBreakMode.byWordWrapping
+        label.font = UIFont(name: fontName, size: fontSize)
+
+        label.text = "(Press and hold to skip)"
+
+        label.sizeToFit()
+
+        let view = Animate(label)
+        view.wait(asec: 1.5, then: {
+            self.addSubview(label)
+            view.fadeIn(then: {
+                view.setDuration(4).fade(to: 0.2)
+                view.wait(asec: 1.5, then: {
+                    view.setDuration(view.originalDuration).move(to: [-self.bounds.width * 2, 0], then: {
+                        label.removeFromSuperview()
+                    })
+                })
+            })
+        })
+
     }
 
     /* *******************************
@@ -109,12 +139,27 @@ class StorySequencePlayer: UIView {
         view.addSubview(blurView)
     }
 
+    // test for iPhone X to be able to adjust for the black area in the larger status bar
+    private func isIphoneX() -> Bool {
+        if UIDevice().userInterfaceIdiom == .phone && UIScreen.main.nativeBounds.height == 2436 {
+            return true
+        }
+        return false
+    }
+
+    // return the height of the status bar
+    private func iPhoneXStatusBarHeight() -> CGFloat {
+        return 44
+    }
+
     // layout the image container in the main view, layout the imageviews in the image container, also add the indicator view
     private func layoutImageViews(_ margin: CGFloat, _ height: CGFloat) {
+
         let containerW = self.bounds.width - (margin * 2)
         let containerH = self.bounds.height * height
+        let adjustedW = isIphoneX() ? containerW - iPhoneXStatusBarHeight(): containerW
 
-        imageViewContainer.frame = CGRect(x: margin, y: self.bounds.height - containerH, width: containerW, height: containerH)
+        imageViewContainer.frame = CGRect(x: margin, y: self.bounds.height - containerH, width: adjustedW, height: containerH)
 
         let bounds = imageViewContainer.bounds
         let imageWidth: CGFloat = bounds.width * 0.3
@@ -153,9 +198,12 @@ class StorySequencePlayer: UIView {
 
     // layout the text container
     private func layoutTextContainer(_ margin: CGFloat, _ height: CGFloat) {
+
         let containerW = self.bounds.width - (margin * 2)
         let containerH = (self.bounds.height * height) - (margin * 2)
-        textContainer.frame = CGRect(x: margin, y: margin, width: containerW, height: containerH)
+        let adjustedW = isIphoneX() ? containerW - iPhoneXStatusBarHeight(): containerW
+
+        textContainer.frame = CGRect(x: margin, y: margin, width: adjustedW, height: containerH)
         textContainer.layer.masksToBounds = true
         textContainer.layer.cornerRadius = 12
 

--- a/Powerup/ScenarioViewController.swift
+++ b/Powerup/ScenarioViewController.swift
@@ -160,6 +160,19 @@ class ScenarioViewController: UIViewController, UITableViewDelegate, UITableView
     }
 
     // MARK: OOC Event Functions
+
+    /**
+     Check if the scenario has been previously completed.
+     */
+    func firstTime() -> Bool {
+        do {
+            let scenario: Scenario = try dataSource.getScenario(of: scenarioID)
+            return !scenario.completed
+        } catch _ {
+            return true
+        }
+    }
+
     /**
      Handle starting sequences - opens as an overlay on top of the initial view. Checks if an intro sequence exists for the current scenarioID. Returns if not, otherwise creates an instance of StorySequencePlayer.
 
@@ -172,7 +185,9 @@ class ScenarioViewController: UIViewController, UITableViewDelegate, UITableView
             print("Could not retrieve intro story sequence for scenario \(scenarioID).")
             return
         }
-        let sequenceView: StorySequencePlayer = StorySequencePlayer(delegate: self, model: model)
+
+        //guard let firstTime = dataSource.getScenario(of: scenarioID) else { return false }
+        let sequenceView: StorySequencePlayer = StorySequencePlayer(delegate: self, model: model, firstTime: firstTime())
         self.view.addSubview(sequenceView)
     }
 
@@ -235,7 +250,7 @@ class ScenarioViewController: UIViewController, UITableViewDelegate, UITableView
         }
 
         // create and start the sequence
-        let sequenceView: StorySequencePlayer = StorySequencePlayer(delegate: self, model: model)
+        let sequenceView: StorySequencePlayer = StorySequencePlayer(delegate: self, model: model, firstTime: firstTime())
 
         // set a tag so we can differentiate outros and intros in the delegate method
         sequenceView.tag = 1

--- a/Powerup/ScenarioViewController.swift
+++ b/Powerup/ScenarioViewController.swift
@@ -186,7 +186,6 @@ class ScenarioViewController: UIViewController, UITableViewDelegate, UITableView
             return
         }
 
-        //guard let firstTime = dataSource.getScenario(of: scenarioID) else { return false }
         let sequenceView: StorySequencePlayer = StorySequencePlayer(delegate: self, model: model, firstTime: firstTime())
         self.view.addSubview(sequenceView)
     }


### PR DESCRIPTION
### Description
If a scenario has been previously completed, a story sequence now shows a short notice indicating that a sequence can be skipped by long pressing on the screen.

Fixes # 306

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test.

Starting a new game, the first time through a story sequence does not show the notice. Then, if repeated, it does show the notice.

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
